### PR TITLE
libvirt: update to 9.7.0

### DIFF
--- a/abi_symbols
+++ b/abi_symbols
@@ -9,7 +9,7 @@ libnss_libvirt_guest.so.2:_nss_libvirt_guest_gethostbyname_r
 libvirt-admin.so.0:LIBVIRT_ADMIN_2.0.0
 libvirt-admin.so.0:LIBVIRT_ADMIN_3.0.0
 libvirt-admin.so.0:LIBVIRT_ADMIN_8.6.0
-libvirt-admin.so.0:LIBVIRT_ADMIN_PRIVATE_9.6.0
+libvirt-admin.so.0:LIBVIRT_ADMIN_PRIVATE_9.7.0
 libvirt-admin.so.0:virAdmClientClass
 libvirt-admin.so.0:virAdmClientClose
 libvirt-admin.so.0:virAdmClientFree
@@ -192,7 +192,8 @@ libvirt.so.0:LIBVIRT_8.0.0
 libvirt.so.0:LIBVIRT_8.4.0
 libvirt.so.0:LIBVIRT_8.5.0
 libvirt.so.0:LIBVIRT_9.0.0
-libvirt.so.0:LIBVIRT_PRIVATE_9.6.0
+libvirt.so.0:LIBVIRT_9.7.0
+libvirt.so.0:LIBVIRT_PRIVATE_9.7.0
 libvirt.so.0:cpuDecode
 libvirt.so.0:cpuEncode
 libvirt.so.0:dnsmasqAddDhcpHost
@@ -585,6 +586,10 @@ libvirt.so.0:virCloseCallbacksDomainAlloc
 libvirt.so.0:virCloseCallbacksDomainIsRegistered
 libvirt.so.0:virCloseCallbacksDomainRemove
 libvirt.so.0:virCloseCallbacksDomainRunForConn
+libvirt.so.0:virCloseFrom
+libvirt.so.0:virCloseRange
+libvirt.so.0:virCloseRangeInit
+libvirt.so.0:virCloseRangeIsSupported
 libvirt.so.0:virCommandAbort
 libvirt.so.0:virCommandAddArg
 libvirt.so.0:virCommandAddArgBuffer
@@ -1664,10 +1669,12 @@ libvirt.so.0:virDomainMigrateStartPostCopyEnsureACL
 libvirt.so.0:virDomainMigrateToURI
 libvirt.so.0:virDomainMigrateToURI2
 libvirt.so.0:virDomainMigrateToURI3
+libvirt.so.0:virDomainMomentDefPostParse
 libvirt.so.0:virDomainMomentDropChildren
 libvirt.so.0:virDomainMomentDropParent
 libvirt.so.0:virDomainMomentForEachChild
 libvirt.so.0:virDomainMomentForEachDescendant
+libvirt.so.0:virDomainMomentIsAncestor
 libvirt.so.0:virDomainMomentMoveChildren
 libvirt.so.0:virDomainMomentObjFree
 libvirt.so.0:virDomainMomentObjNew
@@ -2011,6 +2018,7 @@ libvirt.so.0:virDomainSnapshotDefNew
 libvirt.so.0:virDomainSnapshotDefParseString
 libvirt.so.0:virDomainSnapshotDelete
 libvirt.so.0:virDomainSnapshotDeleteEnsureACL
+libvirt.so.0:virDomainSnapshotDiskDefClear
 libvirt.so.0:virDomainSnapshotDiskDefFree
 libvirt.so.0:virDomainSnapshotDiskDefParseXML
 libvirt.so.0:virDomainSnapshotFindByName
@@ -3339,6 +3347,8 @@ libvirt.so.0:virNetworkGetBridgeNameEnsureACL
 libvirt.so.0:virNetworkGetConnect
 libvirt.so.0:virNetworkGetDHCPLeases
 libvirt.so.0:virNetworkGetDHCPLeasesEnsureACL
+libvirt.so.0:virNetworkGetMetadata
+libvirt.so.0:virNetworkGetMetadataEnsureACL
 libvirt.so.0:virNetworkGetName
 libvirt.so.0:virNetworkGetUUID
 libvirt.so.0:virNetworkGetUUIDString
@@ -3372,6 +3382,7 @@ libvirt.so.0:virNetworkObjGetDef
 libvirt.so.0:virNetworkObjGetDnsmasqPid
 libvirt.so.0:virNetworkObjGetFloorSum
 libvirt.so.0:virNetworkObjGetMacMap
+libvirt.so.0:virNetworkObjGetMetadata
 libvirt.so.0:virNetworkObjGetNewDef
 libvirt.so.0:virNetworkObjGetPersistentDef
 libvirt.so.0:virNetworkObjGetPortStatusDir
@@ -3402,11 +3413,13 @@ libvirt.so.0:virNetworkObjSetDefTransient
 libvirt.so.0:virNetworkObjSetDnsmasqPid
 libvirt.so.0:virNetworkObjSetFloorSum
 libvirt.so.0:virNetworkObjSetMacMap
+libvirt.so.0:virNetworkObjSetMetadata
 libvirt.so.0:virNetworkObjTaint
 libvirt.so.0:virNetworkObjUnrefMacMap
 libvirt.so.0:virNetworkObjUnsetDefTransient
 libvirt.so.0:virNetworkObjUpdate
 libvirt.so.0:virNetworkObjUpdateAssignDef
+libvirt.so.0:virNetworkObjUpdateModificationImpact
 libvirt.so.0:virNetworkPortClass
 libvirt.so.0:virNetworkPortCreateXML
 libvirt.so.0:virNetworkPortCreateXMLEnsureACL
@@ -3436,6 +3449,8 @@ libvirt.so.0:virNetworkSaveConfig
 libvirt.so.0:virNetworkSetAutostart
 libvirt.so.0:virNetworkSetAutostartEnsureACL
 libvirt.so.0:virNetworkSetBridgeMacAddr
+libvirt.so.0:virNetworkSetMetadata
+libvirt.so.0:virNetworkSetMetadataEnsureACL
 libvirt.so.0:virNetworkTaintTypeFromString
 libvirt.so.0:virNetworkTaintTypeToString
 libvirt.so.0:virNetworkUndefine
@@ -3630,7 +3645,8 @@ libvirt.so.0:virPCIDeviceFileIterate
 libvirt.so.0:virPCIDeviceFree
 libvirt.so.0:virPCIDeviceGetAddress
 libvirt.so.0:virPCIDeviceGetConfigPath
-libvirt.so.0:virPCIDeviceGetDriverPathAndName
+libvirt.so.0:virPCIDeviceGetCurrentDriverNameAndType
+libvirt.so.0:virPCIDeviceGetCurrentDriverPathAndName
 libvirt.so.0:virPCIDeviceGetIOMMUGroupDev
 libvirt.so.0:virPCIDeviceGetIOMMUGroupList
 libvirt.so.0:virPCIDeviceGetLinkCapSta
@@ -3638,7 +3654,8 @@ libvirt.so.0:virPCIDeviceGetManaged
 libvirt.so.0:virPCIDeviceGetName
 libvirt.so.0:virPCIDeviceGetRemoveSlot
 libvirt.so.0:virPCIDeviceGetReprobe
-libvirt.so.0:virPCIDeviceGetStubDriver
+libvirt.so.0:virPCIDeviceGetStubDriverName
+libvirt.so.0:virPCIDeviceGetStubDriverType
 libvirt.so.0:virPCIDeviceGetUnbindFromStub
 libvirt.so.0:virPCIDeviceGetUsedBy
 libvirt.so.0:virPCIDeviceGetVPD
@@ -3664,7 +3681,8 @@ libvirt.so.0:virPCIDeviceReset
 libvirt.so.0:virPCIDeviceSetManaged
 libvirt.so.0:virPCIDeviceSetRemoveSlot
 libvirt.so.0:virPCIDeviceSetReprobe
-libvirt.so.0:virPCIDeviceSetStubDriver
+libvirt.so.0:virPCIDeviceSetStubDriverName
+libvirt.so.0:virPCIDeviceSetStubDriverType
 libvirt.so.0:virPCIDeviceSetUnbindFromStub
 libvirt.so.0:virPCIDeviceSetUsedBy
 libvirt.so.0:virPCIDeviceUnbind
@@ -5130,6 +5148,8 @@ libvirt.so.0:xdr_remote_network_get_bridge_name_args
 libvirt.so.0:xdr_remote_network_get_bridge_name_ret
 libvirt.so.0:xdr_remote_network_get_dhcp_leases_args
 libvirt.so.0:xdr_remote_network_get_dhcp_leases_ret
+libvirt.so.0:xdr_remote_network_get_metadata_args
+libvirt.so.0:xdr_remote_network_get_metadata_ret
 libvirt.so.0:xdr_remote_network_get_xml_desc_args
 libvirt.so.0:xdr_remote_network_get_xml_desc_ret
 libvirt.so.0:xdr_remote_network_is_active_args
@@ -5154,6 +5174,7 @@ libvirt.so.0:xdr_remote_network_port_lookup_by_uuid_args
 libvirt.so.0:xdr_remote_network_port_lookup_by_uuid_ret
 libvirt.so.0:xdr_remote_network_port_set_parameters_args
 libvirt.so.0:xdr_remote_network_set_autostart_args
+libvirt.so.0:xdr_remote_network_set_metadata_args
 libvirt.so.0:xdr_remote_network_undefine_args
 libvirt.so.0:xdr_remote_network_update_args
 libvirt.so.0:xdr_remote_node_alloc_pages_args
@@ -6849,6 +6870,10 @@ libvirt_iohelper:safewrite
 libvirt_iohelper:safezero
 libvirt_iohelper:stderr
 libvirt_iohelper:virBuildPathInternal
+libvirt_iohelper:virCloseFrom
+libvirt_iohelper:virCloseRange
+libvirt_iohelper:virCloseRangeInit
+libvirt_iohelper:virCloseRangeIsSupported
 libvirt_iohelper:virDirClose
 libvirt_iohelper:virDirCreate
 libvirt_iohelper:virDirIsEmpty

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : libvirt
-version    : 9.6.0
-release    : 60
+version    : 9.7.0
+release    : 61
 source     :
-    - https://libvirt.org/sources/libvirt-9.6.0.tar.xz : 10f2e52dbb5df90410594a8e36d0e0587d38f11efb64ff32cbec422b93b70c52
+    - https://libvirt.org/sources/libvirt-9.7.0.tar.xz : d8c758fe7db640f572489caa8ea6dd8262d169a4372326c23a3a013cdc40b8ce
 license    :
     - GPL-2.0-or-later
     - LGPL-2.1-or-later

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>libvirt</Name>
         <Homepage>https://libvirt.org/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <License>LGPL-2.1-or-later</License>
@@ -164,13 +164,13 @@
             <Path fileType="library">/usr/lib64/libnss_libvirt.so.2</Path>
             <Path fileType="library">/usr/lib64/libnss_libvirt_guest.so.2</Path>
             <Path fileType="library">/usr/lib64/libvirt-admin.so.0</Path>
-            <Path fileType="library">/usr/lib64/libvirt-admin.so.0.9006.0</Path>
+            <Path fileType="library">/usr/lib64/libvirt-admin.so.0.9007.0</Path>
             <Path fileType="library">/usr/lib64/libvirt-lxc.so.0</Path>
-            <Path fileType="library">/usr/lib64/libvirt-lxc.so.0.9006.0</Path>
+            <Path fileType="library">/usr/lib64/libvirt-lxc.so.0.9007.0</Path>
             <Path fileType="library">/usr/lib64/libvirt-qemu.so.0</Path>
-            <Path fileType="library">/usr/lib64/libvirt-qemu.so.0.9006.0</Path>
+            <Path fileType="library">/usr/lib64/libvirt-qemu.so.0.9007.0</Path>
             <Path fileType="library">/usr/lib64/libvirt.so.0</Path>
-            <Path fileType="library">/usr/lib64/libvirt.so.0.9006.0</Path>
+            <Path fileType="library">/usr/lib64/libvirt.so.0.9007.0</Path>
             <Path fileType="library">/usr/lib64/libvirt/connection-driver/libvirt_driver_interface.so</Path>
             <Path fileType="library">/usr/lib64/libvirt/connection-driver/libvirt_driver_lxc.so</Path>
             <Path fileType="library">/usr/lib64/libvirt/connection-driver/libvirt_driver_network.so</Path>
@@ -473,7 +473,7 @@
 </Description>
         <PartOf>programming.devel</PartOf>
         <RuntimeDependencies>
-            <Dependency release="60">libvirt</Dependency>
+            <Dependency release="61">libvirt</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/libvirt/libvirt-admin.h</Path>
@@ -505,12 +505,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="60">
-            <Date>2023-08-12</Date>
-            <Version>9.6.0</Version>
+        <Update release="61">
+            <Date>2023-09-17</Date>
+            <Version>9.7.0</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changes:**
- qemu: basic support for use of "VFIO variant" drivers
- qemu: Various fixes to firmware selection

**Test Plan:**
- Created and launched several VMs (BIOS, UEFI, x64, aarch64)

### Checklist

- [x] Package was built and tested against unstable
